### PR TITLE
Generate better nonces.

### DIFF
--- a/lib/yubikey.js
+++ b/lib/yubikey.js
@@ -152,9 +152,9 @@ Yubikey.prototype = {
    */
   _genNonceAsync: function yubikey__genNonceAsync(callback) {
     // Create a secure, random nonce value
-    crypto.randomBytes(40, function(err, buf) {
+    crypto.randomBytes(30, function(err, buf) {
       if (err) return callback(err);
-      return callback(null, buf.toString('hex').slice(0,40));
+      return callback(null, buf.toString('base64'));
     });
   },
 


### PR DESCRIPTION
The old nonces contained 20 bytes (40 \* 0.5 bytes).
Base64 always maps 3 bytes to 4 characters, so the 40 characters can be
filled with 30 base64-encoded bytes instead.
