### PR TITLE
fixed an issue that was causing crashes if yubico request failed.

### DIFF
--- a/lib/yubikey.js
+++ b/lib/yubikey.js
@@ -84,6 +84,14 @@ Yubikey.prototype = {
             + '/wsapi/2.0/verify?' + this._querify(params, true);
 
     request(uri, function(err, res, body) {
+      if(err) {
+          return callback(err);
+      }
+      else if(!res) {
+          return callback(new Error('No response from Yubico server'));
+      }
+
+
       if (res.statusCode !== 200) {
         return callback(new Error("Server returned code " + res.statusCode));
       }


### PR DESCRIPTION
We were getting crashes on the server that are result of the yubikey library:

,,index.js:272                   -  Uncaught Exception:  TypeError: Cannot read property 'statusCode' of undefined,
,index.js:272                   -     at Object.<anonymous> (/home/ubuntu/sensibill-api-production/node_modules/yubikey/lib/yubikey.js:83:14),
,index.js:272                   -     at self.callback (/home/ubuntu/sensibill-api-production/node_modules/yubikey/node_modules/request/index.js:142:22),
,index.js:272                   -     at Request.EventEmitter.emit (events.js:95:17),
,index.js:272                   -     at ClientRequest.self.clientErrorHandler (/home/ubuntu/sensibill-api-production/node_modules/yubikey/node_modules/request/index.js:246:10),
,index.js:272                   -     at ClientRequest.EventEmitter.emit (events.js:95:17),
,index.js:272                   -     at CleartextStream.socketErrorListener (http.js:1547:9),
,index.js:272                   -     at CleartextStream.EventEmitter.emit (events.js:95:17),
,index.js:272                   -     at SecurePair.<anonymous> (tls.js:1389:19),
,index.js:272                   -     at SecurePair.EventEmitter.emit (events.js:92:17),
,index.js:272                   -     at SecurePair.maybeInitFinished (tls.js:982:10),
,,index.js:264                   -  About to exit with code:  255,

I just added in graceful handling of the error conditions causing the crash. Please pull and npm publish ASAP
